### PR TITLE
Include BitShares/BTS Blockchain

### DIFF
--- a/repositories_tracked.json
+++ b/repositories_tracked.json
@@ -118,5 +118,11 @@
         "repos": [
             "https://github.com/zcash/zcash"
         ]
+    },
+    {
+        "currency": "BTS",
+        "repos": [
+            "https://github.com/bitshares/bitshares-core"
+        ]
     }
 ]


### PR DESCRIPTION
This pull requests adds the bitshares-core repository of the BitShares Blockchain (core native token BTS).

I would like to emphasise that this repository only contains the codebase for the blockchain software.
Frontend/UI has its [own repository](https://github.com/bitshares/bitshares-ui) as well as several other repositories for libraries, frameworks and applications that build on top of the BitShares Blockchain.