### PR TITLE
Add Decred repositories

### DIFF
--- a/repositories_tracked.json
+++ b/repositories_tracked.json
@@ -118,5 +118,17 @@
         "repos": [
             "https://github.com/zcash/zcash"
         ]
-    }
+    },
+        {
+        "currency": "DCR",
+        "repos": [
+            "https://github.com/decred/dcrd",
+            "https://github.com/decred/dcrwallet",
+            "https://github.com/decred/decrediton"
+            "https://github.com/decred/dcrandroid",
+            "https://github.com/decred/politeia",
+            "https://github.com/decred/dcrtime",
+            "https://github.com/decred/atomicswap"
+        ]
+}
 ]


### PR DESCRIPTION
I would like you to consider adding Decred to the analysis and tracking these repositories. In addition to the wallet and node repositories there are several which are being actively used by other projects (atomicswap, drctime) and others with great potential in that regard (politeia).

Descriptions:
https://github.com/decred/dcrd - daemon
https://github.com/decred/dcrwallet - wallet tools
https://github.com/decred/decrediton - GUI wallet
https://github.com/decred/dcrandroid -Android wallet that uses Decred's P2P SPV
https://github.com/decred/politeia - Governance proposal submission and discussion platform with transparent censorship
https://github.com/decred/dcrtime - Blockchain timestamping of documents, used by Politeia and at least two companies who offer it as a service.
https://github.com/decred/atomicswap - Atomic swap tools. This repository has been forked (and used) by QTUM, Viacoin, Vertcoin, Particl, and Bitcoin Atom, among others.